### PR TITLE
add mor packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ RoxygenNote: 7.2.0
 URL: https://github.com/rstudio-conf-2022/btt22
 BugReports: https://github.com/rstudio-conf-2022/btt22/issues
 Imports: 
+    cffr,
     cli,
     desc,
     devtools (>= 2.4.3),
@@ -27,10 +28,13 @@ Imports:
     fs,
     gert,
     ggplot2 (>= 3.3.6),
+    knitr,
     magrittr,
     palmerpenguins,
+    pkgdown,
     purrr,
     rlang,
+    rmarkdown,
     rprojroot,
     shiny (>= 1.7.1),
     usethis,
@@ -39,8 +43,6 @@ Imports:
     yesno,
     zip
 Suggests: 
-    knitr,
-    rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: btt22
 Title: Templating functions for "Building Tidy Tools 2022"
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: 
   c(
     person("Ian", "Lyttle", , "ijlyttle@me.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# btt22 0.0.7
+
+* Add more packages to imports, so that they will be installed automatically. (#25)
+
 # btt22 0.0.6
 
 * Remove base pipe so that folks with R v3 can still use. 

--- a/R/imports.R
+++ b/R/imports.R
@@ -9,6 +9,10 @@ gratuitous_references <- function() {
   ggplot2::ggplot
   palmerpenguins::penguins
   shiny::h1
+  pkgdown::build_site
+  knitr::knit
+  rmarkdown::render
+  cffr::cff_write
 
   invisible(NULL)
 }


### PR DESCRIPTION
fix #25 

We are getting the dreaded "too many imports" note from R CMD CHECK:

```
  Imports includes 23 non-default packages.
  Importing from so many packages makes the package vulnerable to any of
  them becoming unavailable.  Move as many as possible to Suggests and
  use conditionally.
```

This will *never* come close to CRAN, so I'm not going to worry.